### PR TITLE
Optimize AST processing

### DIFF
--- a/utils/ast_to_png.py
+++ b/utils/ast_to_png.py
@@ -86,7 +86,8 @@ def visualize_call_flow(
     # 함수 정의 정보 수집
     for file_path in file_paths:
         try:
-            source_code = open(file_path, encoding='utf-8').read()
+            with open(file_path, encoding='utf-8') as f:
+                source_code = f.read()
             syntax_tree = ast.parse(source_code)
         except Exception:
             continue
@@ -116,7 +117,8 @@ def visualize_call_flow(
     # 호출 그래프 생성 및 타겟 호출 수집
     for file_path in file_paths:
         try:
-            source_code = open(file_path, encoding='utf-8').read()
+            with open(file_path, encoding='utf-8') as f:
+                source_code = f.read()
             syntax_tree = ast.parse(source_code)
         except Exception:
             continue

--- a/utils/ast_utils.py
+++ b/utils/ast_utils.py
@@ -54,7 +54,6 @@ def uses_request(function_node: ast.AST) -> bool:
 def collect_functions(syntax_tree: ast.Module) -> dict[str, dict]:
     visitor = FuncVisitor()
     visitor.visit(syntax_tree)
-    FuncVisitor().visit(syntax_tree)
     return visitor.function_info_map
 
 


### PR DESCRIPTION
## Summary
- avoid redundant visitor pass in `collect_functions`
- close files properly when reading source

## Testing
- `python -m py_compile main.py utils/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688184e4dea483338d961a6a351be691